### PR TITLE
Add Mgodatagen

### DIFF
--- a/_tools/Mgodatagen
+++ b/_tools/Mgodatagen
@@ -1,0 +1,59 @@
+---
+# Tool name
+name: mgodatagen
+
+# Software language (if applicable, see _data/attr.yml)
+language: Go
+
+# License (should be listed in _data/attr.yml)
+license: MIT
+
+# Maintained: "Actively Maintained" or "Inactive"
+maintained: Actively Maintained
+
+# url of support forum
+support: 
+
+# homepage url
+officialUrl: https://github.com/feliixx/mgodatagen
+
+# supported operating systems (if applicable)
+environments:
+- apple
+- linux
+- windows
+
+# (optional) fully supported MongoDB versions that have been tested
+mongodb_versions:
+- 2.6
+- 3.0
+- 3.2
+- 3.4
+
+# (optional) minimum MongoDB version
+minimum_mongodb_version: 2.6
+
+# (optional) Support for MongoDB Enterprise features? None, Limited, Full
+mongodb_enterprise_support: 
+
+# Purpose (see _data/attr.yml for valid choices)
+purpose: Diagnostics & Performance Tuning
+
+# Short description of tool
+description: A small CLI tool to quickly generate millions of pseudo-random BSON documents and insert them into a Mongodb instance. Test how your application responds when your database grows.
+
+# image should be added to the img/ directory, ideally 370x200px
+img: 
+
+# Release Info
+latest_release_version: 0.0.1
+latest_release_date: 2017-08-11
+
+# Github Info
+github_user: feliixx
+github_repo: mgodatagen
+
+# Do not change the following settings
+layout: tool
+
+---


### PR DESCRIPTION
Add mgodatagen, a tool to generate pseudo-random BSON documents from a schema and insert them in MongoDB