### PR TITLE
Updated _tools

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   redcarpet
 
 BUNDLED WITH
-   1.15.4
+   2.1.2

--- a/_tools/Spring Data MongoDB.md
+++ b/_tools/Spring Data MongoDB.md
@@ -46,8 +46,8 @@ description: Spring-based, POJO-centric model for interacting with a MongoDB DBC
 img: spring-data-mongodb.png
 
 # Release Info
-latest_release_version: 1.10.7
-latest_release_date: 2017-01-26
+latest_release_version: 3.0.0
+latest_release_date: 2020-01-17
 
 # Github Info
 github_user: spring-projects

--- a/_tools/The C Driver.md
+++ b/_tools/The C Driver.md
@@ -32,6 +32,7 @@ mongodb_versions:
 - 3.4
 - 3.6
 - 4.0
+- 4.2
 
 # (optional) minimum MongoDB version
 minimum_mongodb_version:
@@ -49,8 +50,8 @@ description: The officially supported client interface for C applications.
 img: c.png
 
 # Release Info
-latest_release_version: 1.14.0
-latest_release_date: 2019-02-22
+latest_release_version: 1.16.0
+latest_release_date: 2020-01-17
 
 # Github Info
 github_user: mongodb

--- a/_tools/The C# Driver.md
+++ b/_tools/The C# Driver.md
@@ -31,6 +31,7 @@ mongodb_versions:
 - 3.4
 - 3.6
 - 4.0
+- 4.2
 
 # (optional) minimum MongoDB version
 minimum_mongodb_version:
@@ -48,8 +49,8 @@ description: The officially supported client interface for C# applications.
 img: csharp.png
 
 # Release Info
-latest_release_version: 2.8.1
-latest_release_date: 2019-05-15
+latest_release_version: 2.10.1
+latest_release_date: 2020-01-17
 
 # Github Info
 github_user: mongodb

--- a/_tools/The C++11 Driver.md
+++ b/_tools/The C++11 Driver.md
@@ -50,7 +50,7 @@ img:
 
 # Release Info
 latest_release_version: C++11 3.4.0
-latest_release_date: 2018-10-15
+latest_release_date: 2018-10-1
 
 # Github Info
 github_user: mongodb

--- a/_tools/The Java Driver.md
+++ b/_tools/The Java Driver.md
@@ -49,8 +49,8 @@ description: The officially supported client interface for Java applications.
 img: 
 
 # Release Info
-latest_release_version: 3.10.2
-latest_release_date: 2019-04-08
+latest_release_version: 3.12.1
+latest_release_date: 2020-01-17
 
 # Github Info
 github_user: mongodb

--- a/_tools/The Node Driver.md
+++ b/_tools/The Node Driver.md
@@ -32,6 +32,7 @@ mongodb_versions:
 - 3.4
 - 3.6
 - 4.0
+- 4.2
 
 # (optional) minimum MongoDB version
 minimum_mongodb_version:
@@ -49,8 +50,8 @@ description: The officially supported client interface for Node.js applications.
 img: node.png
 
 # Release Info
-latest_release_version: 3.2.1
-latest_release_date: 2019-03-21
+latest_release_version: 3.5.2
+latest_release_date: 2020-01-21
 
 # Github Info
 github_user: mongodb

--- a/_tools/The PHP Driver.md
+++ b/_tools/The PHP Driver.md
@@ -35,6 +35,7 @@ mongodb_versions:
 - 3.4
 - 3.6
 - 4.0
+- 4.2
 
 # (optional) minimum MongoDB version
 minimum_mongodb_version:
@@ -49,8 +50,8 @@ description: The officially supported client interface for PHP applications.
 img: 
 
 # Release Info
-latest_release_version: 1.5.5
-latest_release_date: 2019-06-10
+latest_release_version: 1.6.1
+latest_release_date: 2019-12-06
 
 # Github Info
 github_user: mongodb

--- a/_tools/The Perl Driver.md
+++ b/_tools/The Perl Driver.md
@@ -49,8 +49,8 @@ description: The officially supported client interface for Perl applications.
 img: 
 
 # Release Info
-latest_release_version: 2.0.3
-latest_release_date: 2019-02-07
+latest_release_version: 2.2.1
+latest_release_date: 2019-12-13
 
 # Github Info
 github_user: mongodb

--- a/_tools/The Ruby Driver.md
+++ b/_tools/The Ruby Driver.md
@@ -32,6 +32,7 @@ mongodb_versions:
 - 3.4
 - 3.6
 - 4.0
+- 4.2
 
 # (optional) minimum MongoDB version
 minimum_mongodb_version:
@@ -49,8 +50,8 @@ description: The officially supported client interface for Ruby applications.
 img: ruby.png
 
 # Release Info
-latest_release_version: 2.8.0
-latest_release_date: 2019-03-21
+latest_release_version: 2.11.3
+latest_release_date: 2020-01-24
 
 # Github Info
 github_user: mongodb

--- a/_tools/studio-3t.md
+++ b/_tools/studio-3t.md
@@ -47,11 +47,11 @@ description: Studio 3T is a fully featured IDE for MongoDB. The best MongoDB GUI
 img: studio-3t.png
 
 # Release Info
-latest_release_version: 5.3.4
-latest_release_date: 2017-06-19
+latest_release_version: 2020.1
+latest_release_date: 2020-01-07
 
 # Github Info
-github_user: 
+github_user: Studio3T
 github_repo: 
 
 # Do not change the following settings


### PR DESCRIPTION
Updated _tools:

- MongoDB Compatible versions

- URLS

- Latest Release Version and Date

- GitHub User and Repo

Some notes (not updated in this PR, would like insight for these):

- [ ] MongoBooster.md -> was officially renamed to NoSQLBooster

- [ ] MongoDB Cloud Manager Automation.md, Backup.md, Monitoring.md Versions -> is it safe to say since these are on mongodb.com that they supports all mongodb versions?

- [ ] Mongoclient.md -> was officially renamed to NoSQLClient

- [ ] Slamdata github_repo is wrong, it's just the user, erase instead?

- [ ] Could not find much info about SlamData, I see a lot of info about Quasar, but unsure if related since Quasar comes up with a lot of SQL stuff

- [ ] The Java Driver has a beta version, only added stable version

- [ ] Perl Driver = END OF LIFE NOTICE: Version v2.2.0 is the final feature release of the MongoDB Perl driver. The driver is now in a 12-month "sunset" period and will receive security patches and critical bug fixes only. The Perl driver will be end-of-life and unsupported on August 13, 2020.


- [ ] Might be good to let the web team know:
http://docs.mongodb.org/ecosystem/drivers/c/ -> version in URL is not updated with latest release
http://docs.mongodb.org/ecosystem/drivers/csharp/ -> version in URL not updated with latest release



